### PR TITLE
adding useful example functions to support dynamic arguments

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,7 +11,7 @@ PY_LDFLAGS := -L$(PY_LIBDIR) -lpython$(PY_VER) -Wl,-rpath -Wl,$(PY_LIBDIR)
 PYBIND11_CPPFLAGS := $(shell python3 -m pybind11 --includes)
 
 
-CXXFLAGS := -g -Wall -Werror
+CXXFLAGS := -g -Wall -Werror -std=c++11
 
 SLIBS := mod.so
 mod.lo_CPPFLAGS := $(PY_CFLAGS) $(PYBIND11_CPPFLAGS)

--- a/mod.cpp
+++ b/mod.cpp
@@ -10,6 +10,48 @@
 
 namespace py = pybind11;
 
+void print_pyobject(py::object o)
+{
+    if (py::isinstance<py::dict>(o)) {
+        size_t i=0, n=py::dict(o).size();
+        printf("{");
+        for (auto p: py::dict(o)) {
+            std::string k = py::cast<std::string>(p.first);
+            auto        v = py::cast<py::object> (p.second);
+            printf("\"%s\":", k.c_str());
+            print_pyobject(py::cast<py::object>(v));
+            printf("%s", ++i==n ? "" : ",");
+        }
+        printf("}");
+    } else if (py::isinstance<py::list>(o) || py::isinstance<py::tuple>(o)) {
+        size_t i=0, n=py::list(o).size();
+        printf("[");
+        for (auto v: py::list(o)) {
+            print_pyobject(py::cast<py::object>(v));
+            printf("%s", ++i==n ? "" : ",");
+        }
+        printf("]");
+    } else if (py::isinstance<py::bool_>(o)) {
+        printf("%s", bool(py::bool_(o)) ? "true" : "false");
+    } else if (py::isinstance<py::int_>(o)) {
+        printf("%d", int(py::int_(o)));
+    } else if (py::isinstance<py::float_>(o)) {
+        printf("%g", float(py::float_(o)));
+    } else if (py::isinstance<py::none>(o)) {
+        printf("null");
+    } else if (py::isinstance<py::str>(o)) {
+        printf("\"%s\"", std::string(py::str(o)).c_str());
+    } else {
+        printf("?\n");
+    }
+}
+
+int white(py::object v=py::none())
+{
+    print_pyobject(v);
+    printf("\n");
+    return 0;
+}
 
 // I know this is not the form that I want.
 //
@@ -43,4 +85,6 @@ PYBIND11_MODULE(mod,m) {
     m.doc() = "pybind11 example plugin";
 
     m.def("magic", &magic, "Magic function");
+    m.def("white", &white, "Down the rabbit hole",
+          py::arg("v")=py::none());
 }

--- a/mod.cpp
+++ b/mod.cpp
@@ -10,6 +10,8 @@
 
 namespace py = pybind11;
 
+// recursive function to print a python object (while there are better ways to
+// print, this demonstrates parsing simple or complex python types)
 void print_pyobject(py::object o)
 {
     if (py::isinstance<py::dict>(o)) {
@@ -53,6 +55,19 @@ int white(py::object v=py::none())
     return 0;
 }
 
+int rabbit(py::args args)
+{
+    for (auto arg: args) {
+        // 'arg' is of type py::handle which for some reason causes
+        // problems with casting to specific pybind instances; casting
+        // as a py::object fixes this. There are probably better methods...
+        print_pyobject( py::cast<py::object>(arg) );
+        printf(",");
+    }
+    printf("\n");
+    return 0;
+}
+
 // I know this is not the form that I want.
 //
 // It needs to have generic arguments.  I need to parse the arguments that
@@ -87,4 +102,5 @@ PYBIND11_MODULE(mod,m) {
     m.def("magic", &magic, "Magic function");
     m.def("white", &white, "Down the rabbit hole",
           py::arg("v")=py::none());
+    m.def("rabbit", &rabbit, "Alice");
 }

--- a/runTest
+++ b/runTest
@@ -30,6 +30,14 @@ mod.white((1,2,None,"white","black",))
 # print more complex dictionary types
 mod.white({'a':12, 'b':88, 'c':[1,2,3,4,], 'd':{'white':'white'}})
 
+# variable number of arguments
+mod.rabbit(0)
+mod.rabbit(0,1)
+mod.rabbit(0,1,2,3,4,5)
+
+# print with a mix of values
+mod.rabbit(0,1,2,"wonderland",{'a':1, 'b':2}, ("this","is","a","tuple"))
+
 '''
 
 # I want magic to take any number and type of arguments.

--- a/runTest
+++ b/runTest
@@ -18,6 +18,20 @@ import mod
 print(mod.magic(3, 4))
 #print([4, "foo", { "bar", 5, 6 } ])
 
+# print primitives
+mod.white(12)
+mod.white(None)
+mod.white("hello")
+
+# print lists/tuples
+mod.white([1,2,None,"white","black",])
+mod.white((1,2,None,"white","black",))
+
+# print more complex dictionary types
+mod.white({'a':12, 'b':88, 'c':[1,2,3,4,], 'd':{'white':'white'}})
+
+'''
+
 # I want magic to take any number and type of arguments.
 
 # this will fail.  I'd like the mod.magic() to be able to
@@ -26,4 +40,4 @@ print(mod.magic(3, 4, 5))
 
 # I want magic to work with any arguments:
 print(mod.magic([4, "foo", { "bar", 5, 6 } ], "cake", "pie"))
-
+'''


### PR DESCRIPTION
The C++ interface is purely pythonic which isn't exactly what you're looking for, but the data types you're wanting to pass into it are probably too complex to be native to C++ anyway.

Building and running on my system gives:

```
mod.cpp:92:magic: got 3 4
12
12
null
"hello"
[1,2,null,"white","black"]
[1,2,null,"white","black"]
{"a":12,"b":88,"c":[1,2,3,4],"d":{"white":"white"}}
0,
0,1,
0,1,2,3,4,5,
0,1,2,"wonderland",{"a":1,"b":2},["this","is","a","tuple"],
```